### PR TITLE
Fix `update` call

### DIFF
--- a/clj2nix.clj
+++ b/clj2nix.clj
@@ -152,8 +152,8 @@
         deps-edn-data (update
                        (edn/read-string
                         (slurp deps-edn-path))
-                       merge
                        :mvn/repos
+                       merge
                        mvn/standard-repos)
         aliases (->> (:alias options)
                      (map (fn [alias] (get-in deps-edn-data [:aliases alias])))


### PR DESCRIPTION
After this, I can successfully run:

```
clj2nix deps.edn test-deps.nix -A:test
```

Closes #1.