### PR TITLE
Fix -M warning for clojure >= 1.10.1.697

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -23,7 +23,10 @@ in stdenv.mkDerivation rec {
 
       cp ${src} $out/bin
       makeWrapper ${clojure}/bin/clojure $out/bin/clj2nix \
-        --add-flags "-Scp ${classp} -i ${src} -m clj2nix ${version}" \
+        --add-flags "-Scp ${classp} ${
+          if (lib.versionAtLeast clojure.version "1.10.1.697")
+            then "-M ${src}" else "-i ${src} -m clj2nix"
+        } ${version}" \
         --prefix PATH : "$PATH:${lib.makeBinPath [ coreutils nix-prefetch-git ]}"
   '';
 }


### PR DESCRIPTION
Fixes #15

Clojure 1.10.1.697 added the -M flag for invoking a clojure file as a
script, and was added to nixpkgs in this commit:
https://github.com/NixOS/nixpkgs/commit/\
    43776fb11e17781ebffb3bd110b83af224aa5624

We can use `-M <path>` to replace the old `-i <path> -m <ns>` pattern.
