### PR TITLE
docs: quote the classpath in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ in stdenv.mkDerivation {
   # ...whatever here...
 
   installPhase = ''
-      clojure -i somefile.clj -Scp ${classp}
+      clojure -i somefile.clj -Scp "${classp}"
   '';
 }
 ```


### PR DESCRIPTION
Folder names that include digits trigger error `Unreadable arg:` https://clojurians.slack.com/archives/C03S1KBA2/p1727444792457129